### PR TITLE
Update UUID Initialization

### DIFF
--- a/FastImageCache/FastImageCache/FastImageCache/FICUtilities.m
+++ b/FastImageCache/FastImageCache/FastImageCache/FICUtilities.m
@@ -41,7 +41,7 @@ NSString * FICStringWithUUIDBytes(CFUUIDBytes UUIDBytes) {
 }
 
 CFUUIDBytes FICUUIDBytesWithString(NSString *string) {
-    CFUUIDBytes UUIDBytes;
+    CFUUIDBytes UUIDBytes = {};
     CFUUIDRef UUIDRef = CFUUIDCreateFromString(kCFAllocatorDefault, (CFStringRef)string);
     
     if (UUIDRef != NULL) {


### PR DESCRIPTION
Adds explicit UUIDBytes initialization to avoid an Xcode warning