### PR TITLE
Enable direct repo reference in a Cocoapods's Podfile

### DIFF
--- a/FastImageCache.podspec.json
+++ b/FastImageCache.podspec.json
@@ -1,0 +1,24 @@
+{
+  "name": "FastImageCache",
+  "version": "1.5.1",
+  "summary": "iOS library for quickly displaying images while scrolling",
+  "description": "Fast Image Cache is an efficient, persistent, and—above all—fast way to store and retrieve images in your iOS application. Part of any good iOS application's user experience is fast, smooth scrolling, and Fast Image Cache helps make this easier.\n\nA significant burden on performance for graphics-rich applications like Path is image loading. The traditional method of loading individual images from disk is just too slow, especially while scrolling. Fast Image Cache was created specifically to solve this problem.\n",
+  "homepage": "https://github.com/path/FastImageCache",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE"
+  },
+  "authors": {
+    "Mallory Paine": "mpaine@gmail.com",
+    "Michael Potter": "michael@path.com"
+  },
+  "platforms": {
+    "ios": "6.0"
+  },
+  "source": {
+    "git": "https://github.com/path/FastImageCache.git",
+    "tag": "1.5.1"
+  },
+  "source_files": "FastImageCache/FastImageCache/**/*.{h,m}",
+  "requires_arc": true
+}

--- a/FastImageCache.podspec.json
+++ b/FastImageCache.podspec.json
@@ -3,7 +3,7 @@
   "version": "1.5.1",
   "summary": "iOS library for quickly displaying images while scrolling",
   "description": "Fast Image Cache is an efficient, persistent, and—above all—fast way to store and retrieve images in your iOS application. Part of any good iOS application's user experience is fast, smooth scrolling, and Fast Image Cache helps make this easier.\n\nA significant burden on performance for graphics-rich applications like Path is image loading. The traditional method of loading individual images from disk is just too slow, especially while scrolling. Fast Image Cache was created specifically to solve this problem.\n",
-  "homepage": "https://github.com/path/FastImageCache",
+  "homepage": "https://github.com/mallorypaine/FastImageCache",
   "license": {
     "type": "MIT",
     "file": "LICENSE"
@@ -16,7 +16,7 @@
     "ios": "6.0"
   },
   "source": {
-    "git": "https://github.com/path/FastImageCache.git",
+    "git": "https://github.com/mallorypaine/FastImageCache.git",
     "tag": "1.5.1"
   },
   "source_files": "FastImageCache/FastImageCache/**/*.{h,m}",


### PR DESCRIPTION
To reference this repo directly in a Cocoapods's Podfile, the podspec file is expected to be in the root of the repository